### PR TITLE
fix: supported_versions should be decoded before signature, and use u8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 **/*.rs.bk
 .DS_Store
+.idea/*
+melissa.iml

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -22,6 +22,7 @@ pub enum CodecError {
     DecodingError,
 }
 
+#[derive(Debug, Clone)]
 pub struct Cursor {
     buffer: Vec<u8>,
     offset: usize,

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -372,9 +372,12 @@ impl Codec for UserInitKey {
         if algorithm != ED25519 {
             return Err(CodecError::DecodingError);
         }
+
         let identity_key = SignaturePublicKey::decode(cursor)?;
+
+        let supported_versions: Vec<ProtocolVersion> = decode_vec_u8(cursor)?;
+
         let signature = Signature::decode(cursor)?;
-        let supported_versions: Vec<ProtocolVersion> = decode_vec_u16(cursor)?;
         Ok(UserInitKey {
             cipher_suites,
             init_keys,


### PR DESCRIPTION
This is a fix to the order of decoding elements of UserInitKey, plus that supported_versions used encode_vec_u8 for encoding, but decode_vec_u16 for decoding. We decided to use u8 for both.

I added `derive (Debug, Clone)` to `Cursor` to facilitate debugging in the future.